### PR TITLE
Support Vault API ReadWithData

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ func TestPlugin(t *testing.T) {
                 Name:      "testThatPathReturnsX",
                 Operation: stepwise.ReadOperation,
                 Path:      "/path/here",
+				// There's support for ReadOperation with data by passing ReadData 
                 Assert: func (resp *api.Secret, err error) error {
                 
                     // resp.Data contains the `data` part of the response from Vault
@@ -67,8 +68,8 @@ func TestPlugin(t *testing.T) {
 
 Set `SkipTeardown` to `true`, and go into the container with `docker exec -it container-id sh`. Find the container ID with `docker ps`.
 
-When leaving the container running, it's also possible to get the root token, and make API calls directly to Vault.
-For that, run execute `stepwise.Run` instead, create an environment, run it's `Setup()` function, and print the `env.RootToken()` to the command line.
+When leaving the container running, it's possible to get the root token, and make API calls directly to Vault.
+For that, don't execute `stepwise.Run` instead, create an environment, run it's `Setup()` function, and print the `env.RootToken()` to the command line.
 
 # Licensing
 

--- a/stepwise.go
+++ b/stepwise.go
@@ -144,6 +144,9 @@ type Step struct {
 	// Alternatively get data from a function
 	GetData func() (map[string]interface{}, error)
 
+	// ReadData is the data to pass to a read request
+	ReadData map[string][]string
+
 	// Assert is a function that is called after this step is executed in order to
 	// test that the step executed successfully. If this is not set, then the next
 	// step will be called
@@ -327,6 +330,9 @@ func makeRequest(tt TestT, env Environment, step Step) (*api.Secret, error) {
 	case WriteOperation, UpdateOperation:
 		return client.Logical().Write(path, data)
 	case ReadOperation:
+		if step.ReadData != nil {
+			return client.Logical().ReadWithData(path, step.ReadData)
+		}
 		return client.Logical().Read(path)
 	case ListOperation:
 		return client.Logical().List(path)


### PR DESCRIPTION
Certain Read operations require passing arguments to the request, this change adds support for that.