### PR TITLE
Bugfix/running correct image vault

### DIFF
--- a/environments/docker/environment.go
+++ b/environments/docker/environment.go
@@ -614,10 +614,12 @@ func (n *dockerClusterNode) start(cli *docker.Client, caDir, netName string, net
 	r := &Runner{
 		dockerAPI: cli,
 		ContainerConfig: &container.Config{
-			Image: "vault",
-			Entrypoint: []string{"/bin/sh", "-c", "update-ca-certificates && " +
+			Image: n.Cluster.vaultImage,
+			Entrypoint: []string{"/bin/sh", "-c",
 				"exec /usr/local/bin/docker-entrypoint.sh vault server -log-level=trace -dev-plugin-dir=/vault/config -config /vault/config/local.json"},
 			Env: []string{
+				"SKIP_SETCAP=true",
+				"VAULT_LOG_FORMAT=json",
 				"VAULT_CLUSTER_INTERFACE=eth0",
 				"VAULT_API_ADDR=https://127.0.0.1:8200",
 				fmt.Sprintf("VAULT_REDIRECT_ADDR=https://%s:8200", n.Name()),

--- a/environments/docker/environment.go
+++ b/environments/docker/environment.go
@@ -529,19 +529,6 @@ func (n *dockerClusterNode) NewAPIClient() (*api.Client, error) {
 	return apiClient, nil
 }
 
-// ImagePull pull image
-func (n *dockerClusterNode) ImagePull() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	reader, err := n.dockerAPI.ImagePull(ctx, n.Cluster.vaultImage, types.ImagePullOptions{})
-	if err != nil {
-		return err
-	}
-
-	defer reader.Close()
-	return nil
-}
-
 // Cleanup kills the container of the node
 func (n *dockerClusterNode) Cleanup() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -553,11 +540,6 @@ func (n *dockerClusterNode) start(cli *docker.Client, caDir, netName string, net
 	n.dockerAPI = cli
 
 	err := n.setupCert()
-	if err != nil {
-		return err
-	}
-
-	err = n.ImagePull()
 	if err != nil {
 		return err
 	}

--- a/environments/docker/runner.go
+++ b/environments/docker/runner.go
@@ -65,7 +65,7 @@ func (d *Runner) Start(ctx context.Context) (*types.ContainerJSON, error) {
 	}
 
 	cfg := *d.ContainerConfig
-	hostConfig.CapAdd = strslice.StrSlice{"IPC_LOCK"}
+	hostConfig.CapAdd = strslice.StrSlice{"IPC_LOCK", "NET_ADMIN"}
 	cfg.Hostname = d.ContainerName
 	fullName := d.ContainerName
 	container, err := d.dockerAPI.ContainerCreate(ctx, &cfg, hostConfig, networkingConfig, nil, fullName)


### PR DESCRIPTION
in `ImageCreate` the lines below pulled `vault:latest` which is not maintained anymore 
```
ContainerConfig: &container.Config{
			Image: "vault",
```

make use of configured vault Image
```
ContainerConfig: &container.Config{
			Image: n.Cluster.vaultImage,
```

smaller improvements
- remove `imagepull` as not required done via `imagecreate`
- add net_admin to hostconfig cap
- copyToContainer refactored