### PR TITLE
Bugfix/connection issue in init

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ func TestPlugin(t *testing.T) {
 	if err != nil {
 		t.Error("Failed to set environment variable VAULT_ACC")
 	}
-	
+
 	// The mount options are also used for locating and building the plugin
 	mountOptions := stepwise.MountOptions{
 		MountPathPrefix: "plugin-mount-prefix",
@@ -38,25 +38,25 @@ func TestPlugin(t *testing.T) {
 			stepwise.Step{
 				Name:      "testThatPathWrites",
 				Operation: stepwise.WriteOperation,
-				Data:      map[string]interface{}{"field": "value"},
-				// Instead of passing static data, it's possible to use GetData with a function that returns the data    
+				Data:      map[string]any{"field": "value"},
+				// Instead of passing static data, it's possible to use GetData with a function that returns the data
 				Path:      "/path/here",
 			},
 			stepwise.Step{
-                Name:      "testThatPathReturnsX",
-                Operation: stepwise.ReadOperation,
-                Path:      "/path/here",
-				// There's support for ReadOperation with data by passing ReadData 
-                Assert: func (resp *api.Secret, err error) error {
-                
-                    // resp.Data contains the `data` part of the response from Vault
-                    
-                    return nil
-                },
-            },
+				Name:      "testThatPathReturnsX",
+				Operation: stepwise.ReadOperation,
+				Path:      "/path/here",
+				// There's support for ReadOperation with data by passing ReadData
+				Assert: func (resp *api.Secret, err error) error {
+
+					// resp.Data contains the `data` part of the response from Vault
+
+					return nil
+				},
+			},
 		},
 	}
-	
+
     // Running the case compiles the plugin with Docker, and runs Vault with the plugin enabled.
     // Each step in a case is run sequentially.
     // At the end of the case, the Docker container and network are removed, unless `SkipTeardown` is set to `true`

--- a/environments/docker/environment.go
+++ b/environments/docker/environment.go
@@ -167,20 +167,22 @@ func (n *dockerClusterNode) Name() string {
 }
 
 func (dc *Cluster) Initialize(ctx context.Context) error {
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
-
 	client, err := dc.ClusterNodes[0].NewAPIClient()
 	if err != nil {
 		return err
 	}
 
 	var resp *api.InitResponse
-	resp, err = client.Sys().Init(&api.InitRequest{
-		SecretShares:    3,
-		SecretThreshold: 3,
-	})
+	for ctx.Err() == nil {
+		resp, err = client.Sys().Init(&api.InitRequest{
+			SecretShares:    3,
+			SecretThreshold: 3,
+		})
+		if err == nil && resp != nil {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
 	if err != nil {
 		return err
 	}
@@ -353,7 +355,7 @@ func (dc *Cluster) setupCA(opts *ClusterOptions) error {
 	dc.CACertPEM = pem.EncodeToMemory(CACertPEMBlock)
 
 	dc.CACertPEMFile = filepath.Join(dc.tmpDir, "ca", "ca.pem")
-	err = os.WriteFile(dc.CACertPEMFile, dc.CACertPEM, 0o755)
+	err = os.WriteFile(dc.CACertPEMFile, dc.CACertPEM, 0o644)
 	if err != nil {
 		return err
 	}
@@ -419,13 +421,13 @@ func (n *dockerClusterNode) setupCert() error {
 	})
 
 	n.ServerCertPEMFile = filepath.Join(n.WorkDir, "cert.pem")
-	err = os.WriteFile(n.ServerCertPEMFile, n.ServerCertPEM, 0o755)
+	err = os.WriteFile(n.ServerCertPEMFile, n.ServerCertPEM, 0o644)
 	if err != nil {
 		return err
 	}
 
 	n.ServerKeyPEMFile = filepath.Join(n.WorkDir, "key.pem")
-	err = os.WriteFile(n.ServerKeyPEMFile, n.ServerKeyPEM, 0o755)
+	err = os.WriteFile(n.ServerKeyPEMFile, n.ServerKeyPEM, 0o644)
 	if err != nil {
 		return err
 	}
@@ -548,22 +550,22 @@ func (n *dockerClusterNode) start(cli *docker.Client, caDir, netName string, net
 		return err
 	}
 
-	vaultCfg := map[string]interface{}{
-		"listener": map[string]interface{}{
-			"tcp": map[string]interface{}{
+	vaultCfg := map[string]any{
+		"listener": map[string]any{
+			"tcp": map[string]any{
 				"address":       fmt.Sprintf("%s:%d", "0.0.0.0", 8200),
 				"tls_cert_file": "/vault/config/cert.pem",
 				"tls_key_file":  "/vault/config/key.pem",
-				"telemetry": map[string]interface{}{
+				"telemetry": map[string]any{
 					"unauthenticated_metrics_access": true,
 				},
 			},
 		},
-		"telemetry": map[string]interface{}{
+		"telemetry": map[string]any{
 			"disable_hostname": true,
 		},
-		"storage": map[string]interface{}{
-			"inmem": map[string]interface{}{},
+		"storage": map[string]any{
+			"inmem": map[string]any{},
 		},
 		"cluster_name":     netName,
 		"log_level":        "TRACE",
@@ -571,8 +573,8 @@ func (n *dockerClusterNode) start(cli *docker.Client, caDir, netName string, net
 		"disable_mlock":    true,
 	}
 	if n.Cluster.RaftStorage {
-		vaultCfg["storage"] = map[string]interface{}{
-			"raft": map[string]interface{}{
+		vaultCfg["storage"] = map[string]any{
+			"raft": map[string]any{
 				"path":    "/vault/file",
 				"node_id": n.NodeID,
 			},
@@ -785,7 +787,10 @@ func (dc *Cluster) setupDockerCluster(opts *ClusterOptions) error {
 	}
 
 	if opts == nil || !opts.SkipInit {
-		if err := dc.Initialize(context.Background()); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		if err := dc.Initialize(ctx); err != nil {
 			return err
 		}
 	}

--- a/environments/docker/environment.go
+++ b/environments/docker/environment.go
@@ -544,7 +544,11 @@ func (n *dockerClusterNode) NewAPIClient() (*api.Client, error) {
 func (n *dockerClusterNode) Cleanup() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	_, err := n.dockerAPI.ContainerKill(ctx, n.container.ID, docker.ContainerKillOptions{Signal: "KILL"})
+
+	var err error
+	if n.container != nil {
+		_, err = n.dockerAPI.ContainerKill(ctx, n.container.ID, docker.ContainerKillOptions{Signal: "KILL"})
+	}
 
 	return err
 }

--- a/environments/docker/environment.go
+++ b/environments/docker/environment.go
@@ -11,6 +11,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
@@ -34,6 +35,7 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/api/types/registry"
 	docker "github.com/moby/moby/client"
 	"golang.org/x/net/http2"
 )
@@ -85,6 +87,9 @@ type Cluster struct {
 
 	// vaultImage is the docker image to use for running vault. Defaults to 'hashicorp/vault:latest'
 	vaultImage string
+	// registryAuth is the base64-encoded JSON credentials for pulling vaultImage
+	// from a private registry. Set via SetRegistryAuth before calling Run.
+	registryAuth string
 }
 
 // Teardown stops all the containers.
@@ -490,6 +495,23 @@ func NewEnvironment(name string, options *stepwise.MountOptions, vaultImage stri
 	}
 }
 
+// SetRegistryAuth configures credentials for pulling the Vault image from a
+// private registry. Must be called before Run.
+func (dc *Cluster) SetRegistryAuth(username, password, serverAddress string) error {
+	authConfig := registry.AuthConfig{
+		Username:      username,
+		Password:      password,
+		ServerAddress: serverAddress,
+	}
+	authJSON, err := json.Marshal(authConfig)
+	if err != nil {
+		return fmt.Errorf("failed to encode registry auth: %w", err)
+	}
+	dc.registryAuth = base64.URLEncoding.EncodeToString(authJSON)
+
+	return nil
+}
+
 // DockerClusterNode represents a single instance of Vault in a cluster
 type dockerClusterNode struct {
 	NodeID            string
@@ -612,7 +634,8 @@ func (n *dockerClusterNode) start(cli *docker.Client, caDir, netName string, net
 	}
 
 	r := &Runner{
-		dockerAPI: cli,
+		dockerAPI:    cli,
+		RegistryAuth: n.Cluster.registryAuth,
 		ContainerConfig: &container.Config{
 			Image: n.Cluster.vaultImage,
 			Entrypoint: []string{"/bin/sh", "-c",

--- a/environments/docker/environment.go
+++ b/environments/docker/environment.go
@@ -102,8 +102,15 @@ func (dc *Cluster) Teardown() error {
 		if err != nil {
 			return multierror.Append(result, err)
 		}
+		defer cli.Close()
 		if _, err := cli.NetworkRemove(context.Background(), dc.networkID, docker.NetworkRemoveOptions{}); err != nil {
 			return multierror.Append(result, err)
+		}
+	}
+
+	if dc.tmpDir != "" {
+		if err := os.RemoveAll(dc.tmpDir); err != nil {
+			result = multierror.Append(result, err)
 		}
 	}
 
@@ -171,6 +178,7 @@ func (dc *Cluster) Initialize(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer client.CloneConfig().HttpClient.CloseIdleConnections()
 
 	var resp *api.InitResponse
 	for ctx.Err() == nil {
@@ -762,6 +770,7 @@ func (dc *Cluster) setupDockerCluster(opts *ClusterOptions) error {
 	if err != nil {
 		return err
 	}
+	defer cli.Close()
 
 	netUUID, err := uuid.GenerateUUID()
 	if err != nil {
@@ -835,11 +844,11 @@ func (dc *Cluster) Setup() error {
 		return err
 	}
 
-	// tmpDir gets cleaned up when the cluster is cleaned up
 	tmpDir, err := os.MkdirTemp("", "vault-bin-")
 	if err != nil {
 		return err
 	}
+	defer os.RemoveAll(tmpDir)
 
 	binName, binPath, sha256value, err := stepwise.CompilePlugin(registryName, pluginName, srcDir, tmpDir)
 	if err != nil {

--- a/environments/docker/runner.go
+++ b/environments/docker/runner.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/netip"
+	"strings"
 
 	"github.com/moby/go-archive"
 	"github.com/moby/moby/api/types/container"
@@ -62,16 +63,8 @@ func (d *Runner) Start(ctx context.Context) (*container.InspectResponse, error) 
 		}
 	}
 
-	// Best-effort pull. ImageCreate here will use a matching image from the local
-	// Docker library, or if not found pull the matching image from docker hub. If
-	// not found on docker hub, returns an error. The response must be read in
-	// order for the local image to be used.
-	resp, err := d.dockerAPI.ImagePull(ctx, d.ContainerConfig.Image, docker.ImagePullOptions{})
-	if err != nil {
+	if err := d.ensureImage(ctx, d.ContainerConfig.Image); err != nil {
 		return nil, err
-	}
-	if resp != nil {
-		_, _ = io.ReadAll(resp)
 	}
 
 	cfg := *d.ContainerConfig
@@ -109,6 +102,46 @@ func (d *Runner) Start(ctx context.Context) (*container.InspectResponse, error) 
 	}
 
 	return &inspect.Container, nil
+}
+
+// ensureImage pulls the image if needed. For mutable tags (latest or no tag)
+// it always pulls so the local cache stays current. For immutable version tags
+// it skips the pull when the image is already present locally.
+func (d *Runner) ensureImage(ctx context.Context, image string) error {
+	if !isLatestTag(image) {
+		if _, err := d.dockerAPI.ImageInspect(ctx, image); err == nil {
+			return nil
+		}
+	}
+
+	resp, err := d.dockerAPI.ImagePull(ctx, image, docker.ImagePullOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to pull image %q: %w", image, err)
+	}
+	if resp != nil {
+		_, _ = io.ReadAll(resp)
+		resp.Close()
+	}
+
+	return nil
+}
+
+// isLatestTag reports whether an image reference uses a mutable tag (no tag or
+// "latest"). Registry:port prefixes such as "registry:5000/image" are handled
+// correctly: the colon in "registry:5000" is followed by a slash, so it is not
+// mistaken for a tag separator.
+func isLatestTag(image string) bool {
+	i := strings.LastIndex(image, ":")
+	if i == -1 {
+		return true
+	}
+
+	tag := image[i+1:]
+	if strings.ContainsRune(tag, '/') {
+		return true // colon was part of registry:port, not a tag separator
+	}
+
+	return tag == "" || tag == "latest"
 }
 
 func copyToContainer(ctx context.Context, d *docker.Client, containerID, from, to string) error {

--- a/environments/docker/runner.go
+++ b/environments/docker/runner.go
@@ -4,6 +4,7 @@
 package docker
 
 import (
+	"archive/tar"
 	"context"
 	"fmt"
 	"io"
@@ -130,10 +131,57 @@ func copyToContainer(ctx context.Context, d *docker.Client, containerID, from, t
 	}
 	defer content.Close()
 
-	_, err = d.CopyToContainer(ctx, containerID, docker.CopyToContainerOptions{Content: content, DestinationPath: dstDir})
+	normalizedContent := normalizePerms(content)
+	defer normalizedContent.Close()
+
+	_, err = d.CopyToContainer(ctx, containerID, docker.CopyToContainerOptions{Content: normalizedContent, DestinationPath: dstDir})
 	if err != nil {
 		return fmt.Errorf("error copying from %q -> %q: %v", from, to, err)
 	}
 
 	return nil
+}
+
+// normalizePerms rewrites tar headers so that files are 0644 and directories
+// are 0755 inside the container, regardless of the host filesystem permissions.
+// moby preserves host modes verbatim, which breaks containers that
+// run as a non-root user when the source was created with restrictive modes
+// such as 0600 or 0700.
+func normalizePerms(r io.ReadCloser) io.ReadCloser {
+	pr, pw := io.Pipe()
+	go func() {
+		tr := tar.NewReader(r)
+		tw := tar.NewWriter(pw)
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				_ = tw.Close()
+				pw.Close()
+
+				return
+			}
+			if err != nil {
+				pw.CloseWithError(err)
+
+				return
+			}
+			if hdr.Typeflag == tar.TypeDir || hdr.Mode&0o111 != 0 {
+				hdr.Mode = 0o755
+			} else {
+				hdr.Mode = 0o644
+			}
+			if err := tw.WriteHeader(hdr); err != nil {
+				pw.CloseWithError(err)
+
+				return
+			}
+			if _, err := io.Copy(tw, tr); err != nil {
+				pw.CloseWithError(err)
+
+				return
+			}
+		}
+	}()
+
+	return pr
 }

--- a/environments/docker/runner.go
+++ b/environments/docker/runner.go
@@ -25,6 +25,9 @@ type Runner struct {
 	NetName         string
 	IP              string
 	CopyFromTo      map[string]string
+	// RegistryAuth is the base64-encoded JSON credentials for a private image registry.
+	// Use Cluster.SetRegistryAuth to populate this field.
+	RegistryAuth string
 }
 
 // Start is responsible for executing the Vault container. It consists of
@@ -114,7 +117,7 @@ func (d *Runner) ensureImage(ctx context.Context, image string) error {
 		}
 	}
 
-	resp, err := d.dockerAPI.ImagePull(ctx, image, docker.ImagePullOptions{})
+	resp, err := d.dockerAPI.ImagePull(ctx, image, docker.ImagePullOptions{RegistryAuth: d.RegistryAuth})
 	if err != nil {
 		return fmt.Errorf("failed to pull image %q: %w", image, err)
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -28,7 +28,23 @@ func CompilePlugin(name, pluginName, srcDir, tmpDir string) (string, string, str
 	}
 	binPath := path.Join(tmpDir, binName)
 
-	cmd := exec.Command("docker", "run", "--rm", "-v", fmt.Sprintf("%s:%s", tmpDir, tmpDir), "-v", fmt.Sprintf("%s/..:/usr/src/myapp", srcDir), "-w", "/usr/src/myapp", golangImage, "go", "build", "-v", "-o", binPath, path.Join("/usr/src/myapp", pluginName, fmt.Sprintf("cmd/%s/main.go", pluginName)))
+	args := []string{
+		"run", "--rm",
+		"-v", fmt.Sprintf("%s:%s", tmpDir, tmpDir),
+		"-v", fmt.Sprintf("%s/..:/usr/src/myapp", srcDir),
+		"-w", "/usr/src/myapp",
+	}
+
+	if modCache := goModCache(); modCache != "" {
+		args = append(args, "-v", modCache+":/go/pkg/mod")
+	}
+
+	args = append(args, golangImage,
+		"go", "build", "-v", "-o", binPath,
+		path.Join("/usr/src/myapp", pluginName, fmt.Sprintf("cmd/%s/main.go", pluginName)),
+	)
+
+	cmd := exec.Command("docker", args...)
 	cmd.Stdout = &bytes.Buffer{}
 	errOut := &bytes.Buffer{}
 	cmd.Stderr = errOut
@@ -57,6 +73,22 @@ func CompilePlugin(name, pluginName, srcDir, tmpDir string) (string, string, str
 	sha256value := fmt.Sprintf("%x", h.Sum(nil))
 
 	return binName, binPath, sha256value, nil
+}
+
+// goModCache returns the path to the Go module cache on the host, or empty
+// string if it cannot be determined or does not exist.
+func goModCache() string {
+	out, err := exec.Command("go", "env", "GOMODCACHE").Output()
+	if err != nil {
+		return ""
+	}
+
+	dir := strings.TrimSpace(string(out))
+	if _, err := os.Stat(dir); err != nil {
+		return ""
+	}
+
+	return dir
 }
 
 // ReloadFunc are functions that are called when a reload is requested

--- a/stepwise.go
+++ b/stepwise.go
@@ -116,10 +116,10 @@ type Step struct {
 
 	// Arguments to pass in the request. These arguments represent payloads sent
 	// to the API.
-	Data map[string]interface{}
+	Data map[string]any
 
 	// Alternatively get data from a function
-	GetData func() (map[string]interface{}, error)
+	GetData func() (map[string]any, error)
 
 	// BodyData is the data to pass to a read or delete request
 	BodyData map[string][]string
@@ -342,8 +342,8 @@ func checkShouldRun(tt TestT) {
 //
 // Users should just use a *testing.T object, which implements this.
 type TestT interface {
-	Error(args ...interface{})
-	Fatal(args ...interface{})
-	Skip(args ...interface{})
+	Error(args ...any)
+	Fatal(args ...any)
+	Skip(args ...any)
 	Helper()
 }

--- a/stepwise.go
+++ b/stepwise.go
@@ -32,7 +32,6 @@ const (
 	ReadOperation   Operation = "read"
 	DeleteOperation Operation = "delete"
 	ListOperation   Operation = "list"
-	HelpOperation   Operation = "help"
 )
 
 // Environment is the interface Environments need to implement to be used in
@@ -188,10 +187,6 @@ func Run(tt TestT, c Case) {
 
 	logger := logging.NewVaultLogger(log.Trace)
 
-	if err := c.Environment.Setup(); err != nil {
-		tt.Fatal(err)
-	}
-
 	defer func() {
 		if c.SkipTeardown {
 			logger.Info("driver Teardown skipped")
@@ -201,6 +196,10 @@ func Run(tt TestT, c Case) {
 			logger.Error("error in driver teardown:", "error", err)
 		}
 	}()
+
+	if err := c.Environment.Setup(); err != nil {
+		tt.Fatal(err)
+	}
 
 	// retrieve the root client from the Environment. If this returns an error,
 	// fail immediately

--- a/stepwise_test.go
+++ b/stepwise_test.go
@@ -416,28 +416,28 @@ func stepFuncCommon(path string, operation Operation, shouldError bool, unauth b
 // mockT implements TestT for testing
 type mockT struct {
 	ErrorCalled bool
-	ErrorArgs   []interface{}
+	ErrorArgs   []any
 	FatalCalled bool
-	FatalArgs   []interface{}
+	FatalArgs   []any
 	SkipCalled  bool
-	SkipArgs    []interface{}
+	SkipArgs    []any
 
 	f bool
 }
 
-func (t *mockT) Error(args ...interface{}) {
+func (t *mockT) Error(args ...any) {
 	t.ErrorCalled = true
 	t.ErrorArgs = args
 	t.f = true
 }
 
-func (t *mockT) Fatal(args ...interface{}) {
+func (t *mockT) Fatal(args ...any) {
 	t.FatalCalled = true
 	t.FatalArgs = args
 	t.f = true
 }
 
-func (t *mockT) Skip(args ...interface{}) {
+func (t *mockT) Skip(args ...any) {
 	t.SkipCalled = true
 	t.SkipArgs = args
 	t.f = true


### PR DESCRIPTION
The issue that we have with the tests is that the update to use moby docker client caused permissions during `copyToContainer` to not behave the same. Now the content copied to the container maintains the permissions so that a non-root user can access files. 

If a similar problem in the same part of code ever happens again, the code will not get stuck in the loop since the context has a timeout now.

Other changes:
 * Some clients were not closed and temp directories not deleted
 * Reuse pulled docker image whenever possible instead of always pulling
 * Reuse Go cache across tests
 * Remember to call Teardown when setup fails so that tmp directories, networks, etc., are removed
 * Add function `SetRegistryAuth` with which we can pull images via Artifactory